### PR TITLE
Fix pagination

### DIFF
--- a/main.pony
+++ b/main.pony
@@ -85,7 +85,7 @@ primitive GetNextAndLastLink
     var last: (None | String) = None
 
     try
-      let links_string = resp.headers("Link")?
+      let links_string = resp.headers("link")?
 
       let links_parts: Array[String] = links_string.split(",")
 


### PR DESCRIPTION
I noticed that the tool was not fetching all ponylang repositories. There's a bug in the pagination code that causes the code to only fetch the first page of repositories.

---

With the release of ponylang/http#65, all headers are stored converted to lowercase.

Although `Payload.apply` looks up headers in a case-insensitive manner, we [copy the headers as-is][0] into `Response`, so we lose that feature. The fix then is to look all headers converted to lowercase.

[0]: https://github.com/ponylang/pony-sync-helper/blob/b0a63019cb809f9ac883fe678531eaade8a79d8a/asking/asking.pony#L86-L88
