### PR TITLE
Use sync helper to post "good first issues" every week

### DIFF
--- a/.github/workflows/post-good-first-issues.yml
+++ b/.github/workflows/post-good-first-issues.yml
@@ -1,14 +1,13 @@
-name: Post sync agenda
+name: Post good first issues
 
 on:
   workflow_dispatch:
-  repository_dispatch:
-    types:
-      - post-agenda
+  schedule:
+    - cron: '0 14 * * Mon'
 
 jobs:
-  post-agenda:
-    name: Post sync agenda to Zulip
+  post-ISSUES:
+    name: Post good first issues to Zulip
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/ponylang/pony-sync-helper-ci-builder:release
@@ -23,19 +22,19 @@ jobs:
       - name: Run sync-helper
         run: |
           {
-            echo 'AGENDA<<EOF'
-            ./pony-sync-helper --label "discuss during sync" --org ponylang --github_token "$PONY_SYNC_HELPER_GITHUB_TOKEN"
+            echo 'ISSUES<<EOF'
+            ./pony-sync-helper --label "good first issue" --org ponylang --github_token "$PONY_SYNC_HELPER_GITHUB_TOKEN"
             echo 'EOF'
           } >> "$GITHUB_ENV"
         env:
           PONY_SYNC_HELPER_GITHUB_TOKEN: ${{ secrets.PONYLANG_MAIN_API_TOKEN }}
-      - name: Post agenda
+      - name: Post Issues
         uses: zulip/github-actions-zulip/send-message@b62d5a0e48a4d984ea4fce5dd65ba691963d4db4
         with:
           api-key: ${{ secrets.ZULIP_SYNC_EVENT_API_KEY }}
           email: ${{ secrets.ZULIP_SYNC_EVENT_EMAIL }}
           organization-url: 'https://ponylang.zulipchat.com/'
-          to: sync
+          to: contribute to Pony
           type: stream
-          topic: ${{ env.DATE }}
-          content: ${{ env.AGENDA }}
+          topic: Good first issues as of ${{env.DATE}}
+          content: ${{ env.ISSUES }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This is a tool for generating a list of issues to review during the Pony sync meetings, but it can generally be used to retrieve a list of issues from all of the repos belonging to an organization.
+This is a tool for generating a list of issues from Pony repositories. It's primary usage is to generate a list of issues to review during the Pony sync meetings, but it can generally be used to retrieve a list of issues from all of the repos belonging to an organization.
 
 ## Building
 
@@ -20,15 +20,15 @@ To run the program you specify the GitHub org that you want to target.
 
 ```bash
 export PONY_SYNC_HELPER_GITHUB_TOKEN="12345678"
-./pony-sync-helper --org ponylang
+./pony-sync-helper --org ponylang --label "discuss during sync"
 ```
 
 ```bash
-./pony-sync-helper --org ponylang --github_token 12345678
+./pony-sync-helper --org ponylang --label "discuss during sync" --github_token 12345678
 ```
 
 By default only repos with issues are shown. To show all repos, even those without issues, use the `--show_empty` option.
 
 ```bash
-./pony-sync-helper --org ponylang --show_empty --github_token 12345678
+./pony-sync-helper --org ponylang  --label "discuss during sync" --show_empty --github_token 12345678
 ```

--- a/helper_state_machine.pony
+++ b/helper_state_machine.pony
@@ -1,5 +1,6 @@
 use "asking"
 use "collections"
+use  h = "http"
 use "interpolate"
 
 trait val HelperState
@@ -127,7 +128,7 @@ primitive GetRepoIssues
     | let u: String =>
       u
     else
-      "https://api.github.com/repos/" + repo + "/issues?labels=discuss%20during%20sync"
+      "https://api.github.com/repos/" + repo + "/issues?labels=" + h.URLEncode.encode(hsm.ctx.label, h.URLPartQuery)?
     end
 
     Asking(hsm.ctx.auth,
@@ -141,6 +142,7 @@ class Context
   let issues: Map[String, Array[(Issue)]] = Map[String, Array[Issue]]
   let prs: Map[String, Array[(PR)]] = Map[String, Array[PR]]
   let org: String
+  let label: String
   let headers: Array[(String, String)] val
   let show_empty: Bool
   let out: OutStream
@@ -149,6 +151,7 @@ class Context
 
   new create(headers': Array[(String, String)] val,
     org': String,
+    label': String,
     show_empty': Bool,
     out': OutStream,
     err': OutStream,
@@ -156,6 +159,7 @@ class Context
   =>
     headers = headers'
     org = org'
+    label = label'
     show_empty = show_empty'
     out = out'
     err = err'

--- a/main.pony
+++ b/main.pony
@@ -17,6 +17,7 @@ actor Main
           OptionSpec.string("github_token", "GitHub personal access token" where short' = 't', default' = "")
           OptionSpec.bool("show_empty", "Show repos with no issues or PRs" where short' = 'e', default' = false)
           OptionSpec.string("org", "Target org" where short' = 'o')
+          OptionSpec.string("label", "Label to search on" where short' = 'l')
         ]
       )? .> add_help()?
     else
@@ -42,6 +43,8 @@ actor Main
 
     let show_empty = cmd.option("show_empty").bool()
 
+    let label = cmd.option("label").string()
+
     let headers = recover val
       [
         ("Authorization", recover val "token " + token end)
@@ -50,6 +53,7 @@ actor Main
 
     let ctx: Context iso = recover Context(headers,
       org,
+      label,
       show_empty,
       env.out,
       env.err,


### PR DESCRIPTION
This commit updates the sync helper to take a new required command line parameter "label". It then uses this new ability in an additional workflow to post all ponylang organizations "Good first issues" to the Zulip "contribute to Pony" stream once a week.

This was discussed at a sync in the not so distant past as a desirable thing to do as it will increase visibility of easy to get started with issues and we hope, result in more people contributing.