### PR TITLE
Skip archived repos by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,14 @@ export PONY_SYNC_HELPER_GITHUB_TOKEN="12345678"
 ./pony-sync-helper --org ponylang --label "discuss during sync" --github_token 12345678
 ```
 
+By default archived repos are excluded. To include them, use the `--show_archived` option.
+
+```bash
+./pony-sync-helper --org ponylang --label "discuss during sync" --show_archived --github_token 12345678
+```
+
 By default only repos with issues are shown. To show all repos, even those without issues, use the `--show_empty` option.
 
 ```bash
-./pony-sync-helper --org ponylang  --label "discuss during sync" --show_empty --github_token 12345678
+./pony-sync-helper --org ponylang --label "discuss during sync" --show_empty --github_token 12345678
 ```

--- a/helper_state_machine.pony
+++ b/helper_state_machine.pony
@@ -13,6 +13,7 @@ actor SyncHelper
   let _creds: req.Credentials
   let _org: String
   let _label: String
+  let _show_archived: Bool
   let _show_empty: Bool
   let _out: OutStream
   let _err: OutStream
@@ -24,11 +25,12 @@ actor SyncHelper
   let _completed: Set[String] = Set[String]
 
   new create(creds: req.Credentials, org: String, label: String,
-    show_empty: Bool, out: OutStream, err: OutStream)
+    show_archived: Bool, show_empty: Bool, out: OutStream, err: OutStream)
   =>
     _creds = creds
     _org = org
     _label = label
+    _show_archived = show_archived
     _show_empty = show_empty
     _out = out
     _err = err
@@ -44,6 +46,9 @@ actor SyncHelper
     match result
     | let pl: github.PaginatedList[github.Repository] =>
       for repo in pl.results.values() do
+        if repo.archived and (not _show_archived) then
+          continue
+        end
         let name = repo.full_name
         _repos.push(name)
         _issues(name) = Array[github.Issue]

--- a/main.pony
+++ b/main.pony
@@ -9,6 +9,7 @@ actor Main
         "Gather recently modified issues from repos or all repos in a project (defaults to last 7 days)",
         [
           OptionSpec.string("github_token", "GitHub personal access token" where short' = 't', default' = "")
+          OptionSpec.bool("show_archived", "Show archived repos" where short' = 'a', default' = false)
           OptionSpec.bool("show_empty", "Show repos with no issues or PRs" where short' = 'e', default' = false)
           OptionSpec.string("org", "Target org" where short' = 'o')
           OptionSpec.string("label", "Label to search on" where short' = 'l')
@@ -33,11 +34,13 @@ actor Main
 
     let token = cmd.option("github_token").string()
     let org = cmd.option("org").string()
+    let show_archived = cmd.option("show_archived").bool()
     let show_empty = cmd.option("show_empty").bool()
     let label = cmd.option("label").string()
 
     let creds = req.Credentials(TCPConnectAuth(env.root),
       if token == "" then None else token end)
 
-    let helper = SyncHelper(creds, org, label, show_empty, env.out, env.err)
+    let helper = SyncHelper(creds, org, label, show_archived, show_empty,
+      env.out, env.err)
     helper.start()


### PR DESCRIPTION
Archived repos are now excluded when fetching organization repositories.
Pass `--show_archived` / `-a` to include them.

This avoids unnecessary API calls and output noise from repos that are
no longer actively maintained. The filtering happens in `repos_page`
before issue fetching begins, so archived repos don't trigger any API
calls at all.