### PR TITLE
Add missing permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/breakage-against-linux-pony-latest.yml
+++ b/.github/workflows/breakage-against-linux-pony-latest.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [shared-docker-linux-builders-updated]
 
+permissions:
+  packages: read
+
 jobs:
   rebuild-builder:
     name: Update "builder" image

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,9 @@ concurrency:
   group: pr-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  packages: read
+
 jobs:
   superlinter:
     name: Lint bash, docker, markdown, and yaml


### PR DESCRIPTION
Adds explicit permissions blocks to workflows that were missing them, matching the standard permissions used across ponylang projects.