### PR TITLE
Switch container image pruning to snok/container-retention-policy

### DIFF
--- a/.github/workflows/breakage-against-linux-pony-latest.yml
+++ b/.github/workflows/breakage-against-linux-pony-latest.yml
@@ -5,7 +5,7 @@ on:
     types: [shared-docker-linux-builders-updated]
 
 permissions:
-  packages: read
+  packages: write
 
 jobs:
   rebuild-builder:
@@ -101,13 +101,14 @@ jobs:
 
     steps:
       - name: Prune
-        # v4.1.1
-        uses: actions/delete-package-versions@0d39a63126868f5eefaa47169615edd3c0f61e20
+        # v3.0.1
+        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
         with:
-          package-name: ${{ matrix.image }}
-          package-type: 'container'
-          min-versions-to-keep: 1
-          delete-only-untagged-versions: 'true'
+          account: ponylang
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: ${{ matrix.image }}
+          tag-selection: untagged
+          cut-off: 1d
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5


### PR DESCRIPTION
Migrate from actions/delete-package-versions to snok/container-retention-policy for consistency with the multiplatform image pruning already in use in shared-docker and ponyc.

Also fixes the packages permission from read to write, which is required for deleting package versions.