### PR TITLE
Update actions/checkout from v4.1.1 to v6.0.2

### DIFF
--- a/.github/workflows/breakage-against-linux-pony-latest.yml
+++ b/.github/workflows/breakage-against-linux-pony-latest.yml
@@ -12,7 +12,7 @@ jobs:
     name: Update "builder" image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
@@ -38,7 +38,7 @@ jobs:
     name: Update "good first issues" image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
@@ -68,7 +68,7 @@ jobs:
     container:
       image: ghcr.io/ponylang/pony-sync-helper-ci-builder:latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Test with a recent ponyc from main
         run: |
           corral fetch

--- a/.github/workflows/lint-action-workflows.yml
+++ b/.github/workflows/lint-action-workflows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Check workflow files
         uses: docker://ghcr.io/ponylang/shared-docker-ci-actionlint:20260311
         with:

--- a/.github/workflows/post-agenda.yml
+++ b/.github/workflows/post-agenda.yml
@@ -13,7 +13,7 @@ jobs:
     container:
       image: ghcr.io/ponylang/pony-sync-helper-ci-builder:release
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Today's date
         run: echo "DATE=$(date +%Y-%m-%d)" >> "$GITHUB_ENV"
       - name: Build sync-helper

--- a/.github/workflows/post-good-first-issues.yml
+++ b/.github/workflows/post-good-first-issues.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: ghcr.io/ponylang/pony-sync-helper-ci-good-first-issues:release
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Build sync-helper
         run: |
           corral fetch

--- a/.github/workflows/pr-repo-hygiene.yml
+++ b/.github/workflows/pr-repo-hygiene.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint bash, docker, markdown, and yaml
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Lint codebase
         uses: docker://github/super-linter:v3.8.3
         env:
@@ -29,7 +29,7 @@ jobs:
     name: Verify the builder image builds
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v6.0.2
     - name: Build docker image
       working-directory: ./.ci-dockerfiles/builder
       run: docker build . --file Dockerfile
@@ -38,7 +38,7 @@ jobs:
     name: Verify that post-good-first-issues.py passes linting checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
@@ -55,7 +55,7 @@ jobs:
     name: Verify the good-first-issues image builds
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
     container:
       image: ghcr.io/ponylang/pony-sync-helper-ci-builder:release
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Builds with the most recent ponyc nightly
         run: |
           corral fetch


### PR DESCRIPTION
Node 20 reaches EOL in April 2026 and GitHub will force Node 24 after June 2, 2026. v6 already uses Node 24 natively.