### PR TITLE
Upgrade docker/login-action to v4

### DIFF
--- a/.github/workflows/breakage-against-linux-pony-latest.yml
+++ b/.github/workflows/breakage-against-linux-pony-latest.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/pr-repo-hygiene.yml
+++ b/.github/workflows/pr-repo-hygiene.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
The v3 line of docker/login-action uses Node.js 20 which is deprecated by GitHub Actions. v4 upgrades to Node.js 24.

All occurrences across workflow files have been updated.