### PR TITLE
Fix good-first-issues Docker image build

### DIFF
--- a/.ci-dockerfiles/good-first-issues/Dockerfile
+++ b/.ci-dockerfiles/good-first-issues/Dockerfile
@@ -1,7 +1,7 @@
 ARG FROM_TAG=release
 FROM ghcr.io/ponylang/pony-sync-helper-ci-builder:${FROM_TAG}
 
-RUN apk add --update --no-cache \
+RUN apk add --update --upgrade --no-cache \
   python3 \
   python3-dev \
   py3-pip


### PR DESCRIPTION
Alpine's python3 3.12 package was recompiled against expat 2.7.0+ which exports a new symbol (`XML_SetAllocTrackerActivationThreshold`). The base builder image has an older expat without that symbol, so `pyexpat.so` fails to load at import time — which kills pip entirely since pip imports xmlrpc → expat.

Adding `--upgrade` to `apk add` ensures stale dependencies like expat get upgraded alongside the new python3 install.

Fixes the breakage CI failure: https://github.com/ponylang/pony-sync-helper/actions/runs/24271013201