### PR TITLE
Update github_rest_api to 0.7.0

### DIFF
--- a/.ci-dockerfiles/builder/Dockerfile
+++ b/.ci-dockerfiles/builder/Dockerfile
@@ -1,4 +1,4 @@
 ARG FROM_TAG=release
-FROM ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.9.1:${FROM_TAG}
+FROM ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:${FROM_TAG}
 
 RUN apk add --update --no-cache pcre2-dev

--- a/.ci-dockerfiles/builder/build-and-push.bash
+++ b/.ci-dockerfiles/builder/build-and-push.bash
@@ -11,7 +11,7 @@ set -o nounset
 DOCKERFILE_DIR="$(dirname "$0")"
 NAME="ghcr.io/ponylang/pony-sync-helper-ci-builder"
 
-# built from x86-64-unknown-linux-builder release tag
+# built from standard-builder release tag
 FROM_TAG=release
 TAG_AS=release
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
@@ -19,9 +19,9 @@ docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
   "${DOCKERFILE_DIR}"
 docker push "${NAME}:${TAG_AS}"
 
-# built from x86-64-unknown-linux-builder latest tag
-FROM_TAG=latest
-TAG_AS=latest
+# built from standard-builder nightly tag
+FROM_TAG=nightly
+TAG_AS=nightly
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
   -t "${NAME}:${TAG_AS}" \
   "${DOCKERFILE_DIR}"

--- a/.ci-dockerfiles/good-first-issues/build-and-push.bash
+++ b/.ci-dockerfiles/good-first-issues/build-and-push.bash
@@ -16,7 +16,7 @@ set -o nounset
 DOCKERFILE_DIR="$(dirname "$0")"
 NAME="ghcr.io/ponylang/pony-sync-helper-ci-good-first-issues"
 
-# built from x86-64-unknown-linux-builder release tag
+# built from pony-sync-helper-ci-builder release tag
 FROM_TAG=release
 TAG_AS=release
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
@@ -24,9 +24,9 @@ docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
   -f "${DOCKERFILE_DIR}/Dockerfile" .
 docker push "${NAME}:${TAG_AS}"
 
-# built from x86-64-unknown-linux-builder latest tag
-FROM_TAG=latest
-TAG_AS=latest
+# built from pony-sync-helper-ci-builder nightly tag
+FROM_TAG=nightly
+TAG_AS=nightly
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
   -t "${NAME}:${TAG_AS}" \
   -f "${DOCKERFILE_DIR}/Dockerfile" .

--- a/.github/workflows/breakage-against-linux-pony-latest.yml
+++ b/.github/workflows/breakage-against-linux-pony-latest.yml
@@ -66,13 +66,13 @@ jobs:
       - rebuild-builder
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/pony-sync-helper-ci-builder:latest
+      image: ghcr.io/ponylang/pony-sync-helper-ci-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test with a recent ponyc from main
         run: |
           corral fetch
-          corral run -- ponyc -Dopenssl_0.9.0
+          corral run -- ponyc -Dlibressl
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa

--- a/.github/workflows/post-agenda.yml
+++ b/.github/workflows/post-agenda.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build sync-helper
         run: |
           corral fetch
-          corral run -- ponyc -Dopenssl_0.9.0
+          corral run -- ponyc -Dlibressl
       - name: Run sync-helper
         run: |
           {

--- a/.github/workflows/post-good-first-issues.yml
+++ b/.github/workflows/post-good-first-issues.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Build sync-helper
         run: |
           corral fetch
-          corral run -- ponyc -Dopenssl_0.9.0
+          corral run -- ponyc -Dlibressl
       - name: Get good first issues and post to Zulip
         run: |
           ./pony-sync-helper --label "good first issue" --org ponylang --github_token "$PONY_SYNC_HELPER_GITHUB_TOKEN" | /post-good-first-issues.py

--- a/.github/workflows/pr-repo-hygiene.yml
+++ b/.github/workflows/pr-repo-hygiene.yml
@@ -47,9 +47,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build docker image
-        run: docker build --pull --build-arg FROM_TAG="latest" -t "ghcr.io/ponylang/pony-sync-helper-ci-good-first-issues:latest" -f .ci-dockerfiles/good-first-issues/Dockerfile .
+        run: docker build --pull --build-arg FROM_TAG="nightly" -t "ghcr.io/ponylang/pony-sync-helper-ci-good-first-issues:nightly" -f .ci-dockerfiles/good-first-issues/Dockerfile .
       - name: Lint post-good-first-issues.py
-        run: docker run --entrypoint pylint --rm "ghcr.io/ponylang/pony-sync-helper-ci-good-first-issues:latest" /post-good-first-issues.py
+        run: docker run --entrypoint pylint --rm "ghcr.io/ponylang/pony-sync-helper-ci-good-first-issues:nightly" /post-good-first-issues.py
 
   verify-good-first-issues-image-builds:
     name: Verify the good-first-issues image builds
@@ -64,4 +64,4 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build docker image
-        run: docker build --pull --build-arg FROM_TAG="latest" -t "ghcr.io/ponylang/pony-sync-helper-ci-good-first-issues:latest" -f .ci-dockerfiles/good-first-issues/Dockerfile .
+        run: docker build --pull --build-arg FROM_TAG="nightly" -t "ghcr.io/ponylang/pony-sync-helper-ci-good-first-issues:nightly" -f .ci-dockerfiles/good-first-issues/Dockerfile .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Builds with the most recent ponyc nightly
         run: |
           corral fetch
-          corral run -- ponyc -Dopenssl_0.9.0
+          corral run -- ponyc -Dlibressl

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ This is a tool for generating a list of issues from Pony repositories. It's prim
 
 ## Building
 
-It relies on SSL, so you must pass an SSL version to use.
+It relies on SSL, so you must pass an SSL version to use: `-Dopenssl_3.0.x`,
+`-Dopenssl_1.1.x`, or `-Dlibressl`.
 
 ```bash
-corral run -- ponyc -Dopenssl_0.9.0
+corral run -- ponyc -Dopenssl_3.0.x
 ```
 
 ## Usage

--- a/corral.json
+++ b/corral.json
@@ -3,7 +3,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/github_rest_api.git",
-      "version": "0.3.0"
+      "version": "0.7.0"
     }
   ],
   "info": {

--- a/main.pony
+++ b/main.pony
@@ -1,5 +1,5 @@
 use "cli"
-use "net"
+use lori = "lori"
 use req = "github_rest_api/request"
 
 actor Main
@@ -38,7 +38,7 @@ actor Main
     let show_empty = cmd.option("show_empty").bool()
     let label = cmd.option("label").string()
 
-    let creds = req.Credentials(TCPConnectAuth(env.root),
+    let creds = req.Credentials(lori.TCPConnectAuth(env.root),
       if token == "" then None else token end)
 
     let helper = SyncHelper(creds, org, label, show_archived, show_empty,


### PR DESCRIPTION
Bumps github_rest_api from 0.3.0 to 0.7.0. The `Credentials` auth field changed type to `lori.TCPConnectAuth` (github_rest_api 0.3.1), so `main.pony` now builds it from `lori` instead of the stdlib `net` package. Also fixes the stale SSL build flag in the README — `-Dopenssl_0.9.0` no longer exists; the valid options are `-Dopenssl_3.0.x`, `-Dopenssl_1.1.x`, or `-Dlibressl`.