### PR TITLE
Add pony-lint CI workflow

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -1,0 +1,24 @@
+name: pony-lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.pony'
+
+concurrency:
+  group: pony-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  pony-lint:
+    name: Lint Pony source
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint
+        run: pony-lint

--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -21,4 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint
-        run: pony-lint
+        run: |
+          corral fetch
+          corral run -- pony-lint .

--- a/interpolate/interpolate.pony
+++ b/interpolate/interpolate.pony
@@ -1,4 +1,11 @@
+"""
+Simple string interpolation using `{}` placeholders.
+"""
+
 class Interpolate
+  """
+  Replaces `{}` placeholders in a template string with successive arguments.
+  """
   let _template: String
 
   new create(template: String) =>

--- a/main.pony
+++ b/main.pony
@@ -4,23 +4,38 @@ use req = "github_rest_api/request"
 
 actor Main
   new create(env: Env) =>
-    let cs = try
-      CommandSpec.leaf("pony_sync_helper",
-        "Gather recently modified issues from repos or all repos in a project (defaults to last 7 days)",
-        [
-          OptionSpec.string("github_token", "GitHub personal access token" where short' = 't', default' = "")
-          OptionSpec.bool("show_archived", "Show archived repos" where short' = 'a', default' = false)
-          OptionSpec.bool("show_empty", "Show repos with no issues or PRs" where short' = 'e', default' = false)
-          OptionSpec.string("org", "Target org" where short' = 'o')
-          OptionSpec.string("label", "Label to search on" where short' = 'l')
-        ]
-      )? .> add_help()?
-    else
-      env.exitcode(-1)
-      return
-    end
+    let cs =
+      try
+        CommandSpec.leaf(
+          "pony_sync_helper",
+          "Gather recently modified issues from repos or "
+            + "all repos in a project (defaults to last 7 days)",
+          [
+            OptionSpec.string(
+              "github_token",
+              "GitHub personal access token"
+              where short' = 't', default' = "")
+            OptionSpec.bool(
+              "show_archived", "Show archived repos"
+              where short' = 'a', default' = false)
+            OptionSpec.bool(
+              "show_empty",
+              "Show repos with no issues or PRs"
+              where short' = 'e', default' = false)
+            OptionSpec.string(
+              "org", "Target org" where short' = 'o')
+            OptionSpec.string(
+              "label", "Label to search on"
+              where short' = 'l')
+          ]
+        )? .> add_help()?
+      else
+        env.exitcode(-1)
+        return
+      end
 
-    let cmd = match \exhaustive\ CommandParser(cs).parse(env.args, env.vars)
+    let cmd =
+      match \exhaustive\ CommandParser(cs).parse(env.args, env.vars)
       | let c: Command =>
         c
       | let ch: CommandHelp =>
@@ -38,9 +53,18 @@ actor Main
     let show_empty = cmd.option("show_empty").bool()
     let label = cmd.option("label").string()
 
-    let creds = req.Credentials(lori.TCPConnectAuth(env.root),
-      if token == "" then None else token end)
+    let creds =
+      req.Credentials(
+        lori.TCPConnectAuth(env.root),
+        if token == "" then None else token end)
 
-    let helper = SyncHelper(creds, org, label, show_archived, show_empty,
-      env.out, env.err)
+    let helper =
+      SyncHelper(
+        creds,
+        org,
+        label,
+        show_archived,
+        show_empty,
+        env.out,
+        env.err)
     helper.start()

--- a/pony_sync_helper.pony
+++ b/pony_sync_helper.pony
@@ -1,0 +1,4 @@
+"""
+Gathers issues and PRs with a given label across all repositories in a
+GitHub organization and outputs a markdown-formatted summary.
+"""

--- a/sync_helper.pony
+++ b/sync_helper.pony
@@ -24,8 +24,14 @@ actor SyncHelper
     Map[String, Array[github.Issue]]
   let _completed: Set[String] = Set[String]
 
-  new create(creds: req.Credentials, org: String, label: String,
-    show_archived: Bool, show_empty: Bool, out: OutStream, err: OutStream)
+  new create(
+    creds: req.Credentials,
+    org: String,
+    label: String,
+    show_archived: Bool,
+    show_empty: Bool,
+    out: OutStream,
+    err: OutStream)
   =>
     _creds = creds
     _org = org
@@ -38,7 +44,7 @@ actor SyncHelper
   be start() =>
     let p = github.GetOrganizationRepositories(_org, _creds)
     let self: SyncHelper tag = this
-    p.next[None]({(result) => self.repos_page(consume result)})
+    p.next[None]({(result) => self.repos_page(consume result) })
 
   be repos_page(
     result: (github.PaginatedList[github.Repository] | req.RequestError))
@@ -59,7 +65,7 @@ actor SyncHelper
       | let p: Promise[
         (github.PaginatedList[github.Repository] | req.RequestError)] =>
         let self: SyncHelper tag = this
-        p.next[None]({(r) => self.repos_page(consume r)})
+        p.next[None]({(r) => self.repos_page(consume r) })
       | None =>
         _fetch_issues()
       end
@@ -87,7 +93,7 @@ actor SyncHelper
       | let p: Promise[
         (github.PaginatedList[github.Issue] | req.RequestError)] =>
         let self: SyncHelper tag = this
-        p.next[None]({(r) => self.issues_page(repo, consume r)})
+        p.next[None]({(r) => self.issues_page(repo, consume r) })
       | None =>
         _completed.set(repo)
         if _completed.size() == _repos.size() then
@@ -111,10 +117,12 @@ actor SyncHelper
       try
         let owner = parts(0)?
         let repo = parts(1)?
-        let p = github.GetRepositoryIssues(owner, repo, _creds
-          where labels = _label)
+        let p =
+          github.GetRepositoryIssues(
+            owner, repo, _creds where labels = _label)
         let self: SyncHelper tag = this
-        p.next[None]({(r) => self.issues_page(repo_name, consume r)})
+        p.next[None](
+          {(r) => self.issues_page(repo_name, consume r) })
       end
     end
 


### PR DESCRIPTION
Run pony-lint on PRs that touch .pony files, matching the setup used across other ponylang projects. Fix existing lint issues: rename file to match principal type, add package docstrings, fix formatting.