### PR TITLE
Replace super-linter with dedicated linter images

### DIFF
--- a/.github/workflows/pr-repo-hygiene.yml
+++ b/.github/workflows/pr-repo-hygiene.yml
@@ -10,20 +10,21 @@ permissions:
   packages: read
 
 jobs:
-  superlinter:
-    name: Lint bash, docker, markdown, and yaml
+  lint-markdown:
+    name: Lint markdown
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Lint codebase
-        uses: docker://github/super-linter:v3.8.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: true
-          VALIDATE_BASH: true
-          VALIDATE_DOCKERFILE: true
-          VALIDATE_MD: true
-          VALIDATE_YAML: true
+      - name: Lint markdown
+        uses: docker://ghcr.io/ponylang/shared-docker-ci-markdownlint:20260810
+
+  lint-shell:
+    name: Lint shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint shell scripts
+        uses: docker://ghcr.io/ponylang/shared-docker-ci-shellcheck:20260810
 
   verify-builder-image-builds:
     name: Verify the builder image builds

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,1 @@
+{"MD013": false, "MD051": false}


### PR DESCRIPTION
Replace the super-linter Docker image with dedicated markdownlint and shellcheck images from shared-docker. Faster CI — small purpose-built images instead of the 2GB+ super-linter.